### PR TITLE
Communicate cancelation status to remote datasource.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,46 +1,54 @@
 {
-	"author": {
-		"email": "giovanni.calo@live.it",
-		"name": "Giovanni Calò",
-		"url": "https://github.com/giovannicalo"
-	},
-	"bugs": {
-		"url": "https://github.com/giovannicalo/falcor-socket-datasource/issues"
-	},
-	"dependencies": {
-		"falcor": "^0.1.17",
-		"rx": "^4.1.0",
-		"socket.io-client": "^1.4.6",
-		"uuid": "^2.0.2"
-	},
-	"description": "A socket DataSource for Falcor",
-	"devDependencies": {
-		"babel-cli": "^6.8.0",
-		"babel-preset-node-giovanni": "^1.1.2",
-		"chai": "^3.5.0",
-		"coveralls": "^2.11.9",
-		"eslint-config-giovanni": "^2.0.0",
-		"falcor-router": "^0.4.0",
-		"isparta": "^4.0.0",
-		"mocha": "^2.4.5",
-		"posix-cat": "^1.1.1",
-		"rimraf": "^2.5.2",
-		"socket.io": "^1.4.6"
-	},
-	"homepage": "https://github.com/giovannicalo/falcor-socket-datasource",
-	"keywords": ["datasource", "falcor", "socket", "socket.io", "websocket"],
-	"license": "MIT",
-	"main": "dist/index.js",
-	"name": "falcor-socket-datasource",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/giovannicalo/falcor-socket-datasource.git"
-	},
-	"scripts": {
-		"coverage": "babel-node node_modules/isparta/bin/isparta cover node_modules/mocha/bin/_mocha --report lcovonly -- --compilers js:babel-register --recursive && cat coverage/lcov.info | node node_modules/coveralls/bin/coveralls.js && rimraf coverage",
-		"lint": "eslint .",
-		"prepublish": "npm run lint && npm test && babel source --out-dir dist",
-		"test": "mocha --compilers js:babel-register --recursive"
-	},
-	"version": "1.0.4"
+  "author": {
+    "email": "giovanni.calo@live.it",
+    "name": "Giovanni Calò",
+    "url": "https://github.com/giovannicalo"
+  },
+  "bugs": {
+    "url": "https://github.com/giovannicalo/falcor-socket-datasource/issues"
+  },
+  "dependencies": {
+    "socket.io-client": "^1.4.6",
+    "uuid": "^2.0.2"
+  },
+  "description": "A socket DataSource for Falcor",
+  "devDependencies": {
+    "babel-cli": "^6.8.0",
+    "babel-preset-node-giovanni": "^1.1.2",
+    "chai": "^3.5.0",
+    "coveralls": "^2.11.9",
+    "eslint-config-giovanni": "^2.0.0",
+    "falcor": "netflix/falcor",
+    "falcor-router": "^0.4.0",
+    "isparta": "^4.0.0",
+    "mocha": "^2.4.5",
+    "posix-cat": "^1.1.1",
+    "rimraf": "^2.5.2",
+    "rx": "~4.1.0",
+    "rxjs": "~5.0.0-beta.11",
+    "socket.io": "^1.4.6"
+  },
+  "homepage": "https://github.com/giovannicalo/falcor-socket-datasource",
+  "keywords": [
+    "datasource",
+    "falcor",
+    "socket",
+    "socket.io",
+    "websocket"
+  ],
+  "license": "MIT",
+  "main": "dist/index.js",
+  "name": "falcor-socket-datasource",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/giovannicalo/falcor-socket-datasource.git"
+  },
+  "scripts": {
+    "coverage": "babel-node node_modules/isparta/bin/isparta cover node_modules/mocha/bin/_mocha --report lcovonly -- --compilers js:babel-register --recursive && cat coverage/lcov.info | node node_modules/coveralls/bin/coveralls.js && rimraf coverage",
+    "lint": "eslint .",
+    "prepublish": "npm run lint && npm test && babel source --out-dir dist",
+    "test": "_mocha --compilers js:babel-register --recursive",
+    "test-debug": "node --inspect --debug-brk ./node_modules/.bin/_mocha --compilers js:babel-register --recursive"
+  },
+  "version": "1.0.4"
 }

--- a/source/index.js
+++ b/source/index.js
@@ -1,37 +1,103 @@
-import Rx from "rx";
 import SocketIoClient from "socket.io-client";
 import Uuid from "uuid";
 
 export default class FalcorWebSocketDataSource {
 
-	constructor(url, config, event = "falcor") {
-		this.socket = new SocketIoClient(url, config);
+	constructor(...args) {
+		let event = null;
+		let socket = null;
+		let cancel = null;
+
+		if (typeof args[0] === "string") {
+			socket = new SocketIoClient(
+				args.shift(),
+				args[0] && typeof args[0] === "object" ? args.shift() : {}
+			);
+		} else {
+			socket = args.shift();
+		}
+
+		event = args.shift() || "falcor";
+		cancel = args.shift() || "cancel_falcor_operation";
+
+		this.socket = socket;
 		this.event = event;
+		this.cancel = cancel;
 	}
 
 	call(functionPath, args, refSuffixes, thisPaths) {
-		return this.subscribe("call", { args, functionPath, refSuffixes, thisPaths });
+		return this.operation("call", { args, functionPath, refSuffixes, thisPaths });
 	}
 
 	get(pathSets) {
-		return this.subscribe("get", { pathSets });
+		return this.operation("get", { pathSets });
 	}
 
 	set(jsonGraphEnvelope) {
-		return this.subscribe("set", { jsonGraphEnvelope });
+		return this.operation("set", { jsonGraphEnvelope });
 	}
 
-	subscribe(method, parameters) {
-		const id = Uuid();
-		this.socket.emit(this.event, { id, method, ...parameters });
-		return Rx.Observable.create((observer) => {
-			this.socket.on(this.event, (data) => {
-				if (data.id === id) {
-					observer.onNext(data);
-					observer.onCompleted();
+	operation(method, parameters) {
+		return {
+			subscribe: subscribe.bind(this, method, parameters)
+		};
+	}
+
+}
+
+function subscribe(method, parameters, observerOrNext, ...rest) {
+	let observer = observerOrNext;
+
+	if (typeof observerOrNext === "function") {
+		// Falcor internals still expect DataSources to conform to the Rx4 Observer spec.
+		observer = {
+			onCompleted: rest[1],
+			onError: rest[0],
+			onNext: observerOrNext
+		};
+	}
+
+	let acknowledged = false;
+
+	const id = Uuid();
+	const { socket, event, cancel } = this;
+
+	const responseToken = `${event}_${id}`;
+	const cancellationToken = `${cancel}_${id}`;
+
+	socket.on(responseToken, handler);
+	socket.emit(event, { id, method, ...parameters });
+
+	return {
+		dispose() {
+			socket.off(responseToken, handler);
+			if (!acknowledged) {
+				socket.emit(cancellationToken);
+			}
+		}
+	};
+
+	function handler({ error, ...rest }) {
+		// Don't emit the cancelation event if the subscription is
+		// disposed as a result of `error` or `complete`.
+		acknowledged = true;
+		if (typeof error !== "undefined") {
+			// If there's at least one own-property key in ...rest,
+			// notify the subscriber of the data before erroring.
+			for (const restKey in rest) {
+				if (!rest.hasOwnProperty(restKey)) {
+					continue;
 				}
-			});
-		});
+				observer.onNext(rest);
+				break;
+			}
+			observer.onError && observer.onError(error);
+		} else {
+			observer.onNext(rest);
+			// todo: update falcor client and router to support
+			// streaming, then update socket datasource with `nextEvent`
+			// 'errorEvent', and `completeEvent` constructor args.
+			observer.onCompleted && observer.onCompleted();
+		}
 	}
-
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,55 +1,123 @@
 import Chai from "chai";
 import Falcor from "falcor";
+import Rx4 from "rx";
+import Rx5 from "rxjs";
 
-import FalcorSocketDataSource from "../source";
 import Server from "./server";
+import FalcorSocketDataSource from "../source";
+/* eslint-disable */
+import { devDependencies } from "../package";
+/* eslint-enable */
 
 const expect = Chai.expect;
 
 Chai.config.showDiff = true;
 
-describe("Falcor", () => {
-	describe("Socket DataSource", () => {
-		let server = null;
-		let model = null;
-		beforeEach(() => {
-			server = new Server();
-			model = new Falcor.Model({
-				source: new FalcorSocketDataSource(server.getUrl(), { forceNew: true })
+runTestsWithRx(Rx4, devDependencies.rx);
+runTestsWithRx(Rx5, devDependencies.rxjs);
+
+function runTestsWithRx(Rx, rxVersion) {
+	describe(`Falcor Socket DataSource with Rx ${rxVersion}`, () => {
+		describe("Socket DataSource", () => {
+			let server = null;
+			let model = null;
+			beforeEach(() => {
+				server = new Server();
+				model = new Falcor.Model({
+					source: new FalcorSocketDataSource(server.getUrl(), { forceNew: true })
+				});
 			});
-		});
-		it("should get data from the server", (done) => {
-			model.get(["foo", "bar"]).subscribe((data) => {
-				try {
-					expect(data.json.foo.bar).to.equal("foo");
-					done();
-				} catch (error) {
-					done(error);
-				}
+			it("should get data from the server", (done) => {
+				model.get(["foo", "bar"]).subscribe((data) => {
+					try {
+						expect(data.json.foo.bar).to.equal("foo");
+						done();
+					} catch (error) {
+						done(error);
+					}
+				});
 			});
-		});
-		it("should set data on the server", (done) => {
-			model.set({ path: ["foo", "bar"], value: "bar" }).subscribe((data) => {
-				try {
-					expect(data.json.foo.bar).to.equal("bar");
-					done();
-				} catch (error) {
-					done(error);
-				}
+			it("should set data on the server", (done) => {
+				model.set({ path: ["foo", "bar"], value: "bar" }).subscribe((data) => {
+					try {
+						expect(data.json.foo.bar).to.equal("bar");
+						done();
+					} catch (error) {
+						done(error);
+					}
+				});
 			});
-		});
-		it("should call a function on the server", (done) => {
-			model.call("bar", ["foo"]).subscribe((data) => { // eslint-disable-line prefer-reflect
-				try {
-					expect(data.json.foo.bar).to.equal("foo");
-					done();
-				} catch (error) {
-					done(error);
-				}
+			it("should call a function on the server", (done) => {
+				model.call("bar", ["foo"]).subscribe((data) => { // eslint-disable-line prefer-reflect
+					try {
+						expect(data.json.foo.bar).to.equal("foo");
+						done();
+					} catch (error) {
+						done(error);
+					}
+				});
 			});
-		});
-		afterEach(() => {
-			server.socket.close();
+			it("should cancel a get operation", (done) => {
+				const messages = [];
+				const eventName = "falcor";
+				const cancelName = "cancel_falcor_operation";
+				const { _source: { socket } } = model;
+
+				model._source.socket = {
+					emit(event, data, ...rest) {
+						messages.push({ data, event });
+						socket.emit(event, data, ...rest);
+					},
+					off(...args) {
+						return socket.off(...args);
+					},
+					on(...args) {
+						return socket.on(...args);
+					}
+				};
+
+				Rx.Observable
+					.create((observer) => {
+						const disposable = model.get(["long", "running", "operation"]).subscribe(observer);
+						if (!disposable.unsubscribe) {
+							disposable.unsubscribe = disposable.dispose.bind(disposable);
+						} else if (!disposable.dispose) {
+							disposable.dispose = disposable.unsubscribe.bind(disposable);
+						}
+						return disposable;
+					})
+					.timeout(500)
+					.catch((e) => {
+						// delay forwarding the timeout so the stack has time to unwind to unsubscribe
+						return Rx.Observable.of(e).delay(100);
+					})
+					.do(() => {
+						expect(messages.length).to.equal(2);
+
+						const [requestEvent, cancelEvent] = messages;
+						const { id: requestId } = requestEvent.data;
+
+						// validate the request event.
+						expect(requestEvent.event).to.equal(eventName);
+						expect(requestEvent.data.method).to.equal("get");
+						expect(requestEvent.data.pathSets).to.deep.equal([
+							["long", "running", "operation"]
+						]);
+
+						// validate that the cancelation event was send properly
+						expect(cancelEvent.event).to.equal(`${cancelName}_${requestId}`);
+
+						// make sure the route response definitely isn"t in the cache.
+						const { _root: { cache } } = model;
+						expect(typeof cache.long).to.equal("undefined");
+					})
+					.subscribe(() => {
+						// noop
+					}, done, done);
+			});
+			afterEach(() => {
+				server.socket.close();
+			});
 		});
 	});
-});
+}

--- a/test/router.js
+++ b/test/router.js
@@ -1,3 +1,4 @@
+import { Observable } from "rxjs";
 import FalcorRouter from "falcor-router";
 
 export default new FalcorRouter([{
@@ -13,4 +14,13 @@ export default new FalcorRouter([{
 	set: (jsonGraph) => {
 		return { jsonGraph };
 	}
+}, {
+	get: () => {
+		return Observable.timer(5000).map((value) => {
+			return {
+				path: ["long", "running", "operation"], value
+			};
+		});
+	},
+	route: ["long", "running", "operation"]
 }]);


### PR DESCRIPTION
This PR ensures the socket server is notified if the client cancels the operation. I've included tests for RxJS v4 and RxJS v5 to ensure this PR will work when the Falcor client and Router are upgraded to Rx 5.

I've also added a case to the `FalcorWebSocketDataSource` constructor to allow an existing socket to be specified as the first parameter.

Unfortunately, there's a bug in Falcor v0.1.17 (the latest in npm) where Falcor's request batching neglects to cancel in-flight requests even when there's no subscribers. This has been fixed for a long time in master, so I've updated the dependency entry in package.json to reflect this.
